### PR TITLE
Pythv2

### DIFF
--- a/doc/d8x-perpetuals-sdk.md
+++ b/doc/d8x-perpetuals-sdk.md
@@ -5773,6 +5773,7 @@ trader liquidations, trade executions, change of trader margin amount.</p>
         * [.fetchVAAQuery(query)](#PriceFeeds+fetchVAAQuery) ⇒
         * [.fetchPriceQuery(query)](#PriceFeeds+fetchPriceQuery) ⇒
     * _static_
+        * [.trimEndpoint(endp)](#PriceFeeds.trimEndpoint) ⇒
         * [._selectConfig(configs, network)](#PriceFeeds._selectConfig) ⇒
         * [._constructFeedInfo(config)](#PriceFeeds._constructFeedInfo) ⇒
 
@@ -5841,6 +5842,7 @@ it is a direct price feed.</p>
 <ul>
 <li>requires the feeds to be defined in priceFeedConfig.json</li>
 <li>if symbols undefined, all feeds are queried</li>
+<li>vaas are not of interest here</li>
 </ul>
 
 **Kind**: instance method of [<code>PriceFeeds</code>](#PriceFeeds)  
@@ -5904,7 +5906,10 @@ return a triangulated price</p>
 <a name="PriceFeeds+fetchVAAQuery"></a>
 
 ### priceFeeds.fetchVAAQuery(query) ⇒
-<p>Queries the REST endpoint and returns parsed VAA price data</p>
+<p>Queries the REST endpoint and returns parsed VAA price data
+We expect one single id in the query,
+otherwise the VAA is a compressed VAA for all prices which is not suited
+for the smart contracts</p>
 
 **Kind**: instance method of [<code>PriceFeeds</code>](#PriceFeeds)  
 **Returns**: <p>vaa and price info</p>  
@@ -5924,6 +5929,18 @@ return a triangulated price</p>
 | Param | Description |
 | --- | --- |
 | query | <p>query price-info from endpoint</p> |
+
+<a name="PriceFeeds.trimEndpoint"></a>
+
+### PriceFeeds.trimEndpoint(endp) ⇒
+<p>We cut last / or legacy url format /api/ if any</p>
+
+**Kind**: static method of [<code>PriceFeeds</code>](#PriceFeeds)  
+**Returns**: <p>trimmed string</p>  
+
+| Param | Description |
+| --- | --- |
+| endp | <p>endpoint string</p> |
 
 <a name="PriceFeeds._selectConfig"></a>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d8x/perpetuals-sdk",
-  "version": "1.1.33",
+  "version": "1.2.0",
   "description": "Node TypeScript SDK for D8X Perpetual Futures",
   "author": "D8X",
   "homepage": "https://github.com/D8-X/d8x-futures-node-sdk#readme",

--- a/src/config/priceFeedConfig.json
+++ b/src/config/priceFeedConfig.json
@@ -100,7 +100,7 @@
       }
     ],
     "endpoints": [
-      { "type": "pyth", "endpoints": ["https://hermes.pyth.network/api"] },
+      { "type": "pyth", "endpoints": ["https://hermes.pyth.network"] },
       { "type": "onchain", "endpoints": [] }
     ]
   },
@@ -180,6 +180,6 @@
         "origin": "Crypto.USDT/USD"
       }
     ],
-    "endpoints": [{ "type": "odin", "endpoints": ["https://odin.d8x.xyz/api"] }]
+    "endpoints": [{ "type": "odin", "endpoints": ["https://odin.d8x.xyz"] }]
   }
 ]

--- a/src/nodeSDKTypes.ts
+++ b/src/nodeSDKTypes.ts
@@ -270,7 +270,8 @@ export interface PriceFeedConfig {
 }
 
 export interface PriceFeedSubmission {
-  symbols: string[];
+  symbols: Map<string, string[]>; //id -> symbols
+  ids: string[];
   priceFeedVaas: string[];
   prices: number[];
   isMarketClosed: boolean[];

--- a/src/nodeSDKTypes.ts
+++ b/src/nodeSDKTypes.ts
@@ -285,16 +285,25 @@ export interface PriceFeedFormat {
   publish_time: number;
 }
 
-export interface PythLatestPriceFeed {
-  ema_price: {
-    conf: string;
-    expo: number;
-    price: string;
-    publish_time: number;
+export interface PythV2MetaData {
+  slot: number;
+  proof_available_time: number;
+  prev_publish_time: number;
+}
+
+export interface PythV2LatestPriceFeed {
+  binary: {
+    encoding: string;
+    data: string[];
   };
-  id: string;
-  price: PriceFeedFormat;
-  vaa: string;
+  parsed: [
+    {
+      ema_price: PriceFeedFormat;
+      id: string;
+      price: PriceFeedFormat;
+      metadata: PythV2MetaData;
+    }
+  ];
 }
 
 // Payload to be sent to backend when creating

--- a/src/priceFeeds.ts
+++ b/src/priceFeeds.ts
@@ -22,7 +22,7 @@ export default class PriceFeeds {
   private cache: Map<string, { timestamp: number; values: any }> = new Map();
   private onChainPxFeeds: Map<string, OnChainPxFeed>;
   // api formatting constants
-  private PYTH = { endpoint: "/api/latest_price_feeds?ids[]=", separator: "&ids[]=", suffix: "" };
+  private PYTH = { endpoint: "/v2/updates/price/latest?encoding=base64&ids[]=", separator: "&ids[]=", suffix: "" };
 
   constructor(dataHandler: PerpetualDataHandler, priceFeedConfigNetwork: string) {
     let configs = require("./config/priceFeedConfig.json") as PriceFeedConfig[];
@@ -179,6 +179,7 @@ export default class PriceFeeds {
    * Fetch the provided feed prices and bool whether market is closed or open
    * - requires the feeds to be defined in priceFeedConfig.json
    * - if symbols undefined, all feeds are queried
+   * - vaas are not of interest here
    * @param symbols array of feed-price symbols (e.g., [btc-usd, eth-usd]) or undefined
    * @returns mapping symbol-> [price, isMarketClosed]
    */

--- a/src/priceFeeds.ts
+++ b/src/priceFeeds.ts
@@ -440,23 +440,15 @@ export default class PriceFeeds {
     }
     const priceFeedUpdates = new Array<string>();
     const px = new Array<PriceFeedFormat>();
-    const keys = Array.isArray(values) ? [] : Object.keys(values);
-    if (keys.length > 0) {
-      for (const k of keys) {
-        priceFeedUpdates.push("0x");
-        px.push({
-          conf: BigNumber.from(0),
-          expo: -18,
-          price: floatToDec18(values[k].value),
-          publish_time: values[k].timestamp,
-        });
-      }
-    } else {
-      for (let k = 0; k < values.length; k++) {
-        priceFeedUpdates.push("0x" + Buffer.from(values[k].id, "base64").toString("hex"));
-        px.push(values[k].price as PriceFeedFormat);
-      }
+    for (let k = 0; k < values.parsed.length; k++) {
+      // pyth v2 only provides one compressed vaa when querying multiple prices.
+      // contracts can only use separate ones. In case we get only one vaa,
+      // here we add the single vaa in each price-update
+      const idx = k % values.binary.data.length;
+      priceFeedUpdates.push("0x" + Buffer.from(values.binary.data[idx], "base64").toString("hex"));
+      px.push(values.parsed[k].price as PriceFeedFormat);
     }
+
     return [priceFeedUpdates, px];
   }
 

--- a/test/priceFeed.test.ts
+++ b/test/priceFeed.test.ts
@@ -10,14 +10,17 @@ jest.setTimeout(150000);
 
 let config: NodeSDKConfig;
 let mktData: MarketData;
-
+let perp = "BTC-USD-STUSD";
 describe("priceFeed", () => {
   beforeAll(async () => {
     if (pk == undefined) {
       console.log(`Define private key: export PK="CA52A..."`);
       expect(false);
     }
-    config = PerpetualDataHandler.readSDKConfig("xlayer");
+    //config = PerpetualDataHandler.readSDKConfig("xlayer");
+    //perp="BTC-USDT-USDT"
+    config = PerpetualDataHandler.readSDKConfig("arbitrum");
+    perp = "BTC-USD-STUSD";
     if (RPC != undefined) {
       config.nodeURL = RPC;
     }
@@ -48,7 +51,7 @@ describe("priceFeed", () => {
 
   it("get recent prices and submission info for perpetual", async () => {
     let priceFeeds = new PriceFeeds(mktData, config.priceFeedConfigNetwork);
-    let prices = await priceFeeds.fetchLatestFeedPriceInfoForPerpetual("BTC-USDT-USDT");
+    let prices = await priceFeeds.fetchLatestFeedPriceInfoForPerpetual(perp);
     console.log("pyth price info = ", prices.prices);
     console.log("symbols = ", prices.symbols);
   });
@@ -57,7 +60,7 @@ describe("priceFeed", () => {
     let symbolSet = new Set<string>();
     symbolSet.add("ETH-USDC");
     priceFeeds.initializeTriangulations(symbolSet);
-    let prices = await priceFeeds.fetchPricesForPerpetual("ETH-USDC-USDC");
+    let prices = await priceFeeds.fetchPricesForPerpetual(perp);
     console.log("pyth price info = ", prices);
   });
   it("get recent prices", async () => {
@@ -67,7 +70,7 @@ describe("priceFeed", () => {
   });
 
   it("get recent prices from market data directly", async () => {
-    let prices = await mktData.fetchLatestFeedPriceInfo("BTC-USDT-USDT");
+    let prices = await mktData.fetchLatestFeedPriceInfo(perp);
     console.log("pyth price info = ", prices.prices);
     console.log("symbols = ", prices.symbols);
   });
@@ -105,7 +108,7 @@ describe("priceFeed", () => {
     expect(px[1][2]).toBeTruthy(); // market closed
   });
   it("fetch info from data handler", async () => {
-    let l = await mktData.fetchPriceSubmissionInfoForPerpetual("WOKB-USD-WOKB");
+    let l = await mktData.fetchPriceSubmissionInfoForPerpetual(perp);
     console.log(l);
   });
 });

--- a/test/priceFeed.test.ts
+++ b/test/priceFeed.test.ts
@@ -67,7 +67,7 @@ describe("priceFeed", () => {
   });
 
   it("get recent prices from market data directly", async () => {
-    let prices = await mktData.fetchLatestFeedPriceInfo("MATIC-USDC-USDC");
+    let prices = await mktData.fetchLatestFeedPriceInfo("BTC-USDT-USDT");
     console.log("pyth price info = ", prices.prices);
     console.log("symbols = ", prices.symbols);
   });
@@ -79,8 +79,17 @@ describe("priceFeed", () => {
     symbolSet.add("ETH-USDC");
     priceFeeds.initializeTriangulations(symbolSet);
     let timestampSec = Math.floor(Date.now() / 1000);
+    let symbols = new Map<string, string[]>();
+    let ids = new Array<string>();
+    let s = ["BTC-USD", "ETH-USD", "USDC-USD"];
+    for (let j = 0; j < s.length; j++) {
+      const id = "0x" + j.toString();
+      symbols[id] = [s[j]];
+      ids.push(id);
+    }
     let fakeSubmission: PriceFeedSubmission = {
-      symbols: ["BTC-USD", "ETH-USD", "USDC-USD"],
+      symbols: symbols,
+      ids: ids,
       priceFeedVaas: ["", "", ""],
       prices: [20000, 1400, 0.95],
       isMarketClosed: [false, true, false],
@@ -96,7 +105,7 @@ describe("priceFeed", () => {
     expect(px[1][2]).toBeTruthy(); // market closed
   });
   it("fetch info from data handler", async () => {
-    let l = await mktData.fetchPriceSubmissionInfoForPerpetual("ETH-USD-MATIC");
+    let l = await mktData.fetchPriceSubmissionInfoForPerpetual("WOKB-USD-WOKB");
     console.log(l);
   });
 });

--- a/test/priceFeed.test.ts
+++ b/test/priceFeed.test.ts
@@ -27,6 +27,25 @@ describe("priceFeed", () => {
     mktData = new MarketData(config);
     await mktData.createProxyInstance();
   });
+
+  it("trimEndpoint", async () => {
+    let v = "https://blabla.xyz/api/";
+    let res = PriceFeeds.trimEndpoint(v);
+    expect(res == "https://blabla.xyz").toBeTruthy;
+
+    v = "https://blabla.xyz/api";
+    res = PriceFeeds.trimEndpoint(v);
+    expect(res == "https://blabla.xyz").toBeTruthy;
+
+    v = "https://blabla.xyz/";
+    res = PriceFeeds.trimEndpoint(v);
+    expect(res == "https://blabla.xyz").toBeTruthy;
+
+    v = "https://blabla.xyz/api/blabla/";
+    res = PriceFeeds.trimEndpoint(v);
+    expect(res == "https://blabla.xyz/api/blabla").toBeTruthy;
+  });
+
   it("get recent prices and submission info for perpetual", async () => {
     let priceFeeds = new PriceFeeds(mktData, config.priceFeedConfigNetwork);
     let prices = await priceFeeds.fetchLatestFeedPriceInfoForPerpetual("BTC-USDT-USDT");
@@ -43,7 +62,6 @@ describe("priceFeed", () => {
   });
   it("get recent prices", async () => {
     let priceFeeds = new PriceFeeds(mktData, config.priceFeedConfigNetwork);
-    //let query = "https://pyth.testnet.quantena.tech/api/latest_price_feeds?ids[]=0x796d24444ff50728b58e94b1f53dc3a406b2f1ba9d0d0b91d4406c37491a6feb&ids[]=0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b";
     let prices = await priceFeeds.fetchAllFeedPrices();
     console.log("pyth price info = ", prices);
   });


### PR DESCRIPTION
- pyth interface v2: queries in fetchLatestFeedPriceInfoForPerpetual are separated; there we query per perpetual. this is to get vaas individually as required by the smart contracts. Pyth v2 only sends 1 vaa for all price requests if we query at once
- fetchPrices queries all at once and we get one single vaa (which is repeated in the array)
- tests: test/priceFeed.test.ts 