### PR TITLE
add writeEndpoints for price feed endpoints

### DIFF
--- a/src/config/priceFeedConfig.json
+++ b/src/config/priceFeedConfig.json
@@ -106,8 +106,12 @@
       }
     ],
     "endpoints": [
-      { "type": "pyth", "endpoints": ["https://hermes.pyth.network"] },
-      { "type": "onchain", "endpoints": [] }
+      {
+        "type": "pyth",
+        "endpoints": ["https://hermes.pyth.network"],
+        "writeEndpoints": ["https://hermes.pyth.network"]
+      },
+      { "type": "onchain", "endpoints": [], "writeEndpoints": [] }
     ]
   },
   {
@@ -186,6 +190,8 @@
         "origin": "Crypto.USDT/USD"
       }
     ],
-    "endpoints": [{ "type": "odin", "endpoints": ["https://odin.d8x.xyz"] }]
+    "endpoints": [
+      { "type": "odin", "endpoints": ["https://hermes.pyth.network"], "writeEndpoints": ["https://odin.d8x.xyz"] }
+    ]
   }
 ]

--- a/src/nodeSDKTypes.ts
+++ b/src/nodeSDKTypes.ts
@@ -20,7 +20,7 @@ export interface NodeSDKConfig {
   lobFactoryABI?: ContractInterface | undefined;
   lobABI?: ContractInterface | undefined;
   shareTokenABI?: ContractInterface | undefined;
-  priceFeedEndpoints?: Array<{ type: string; endpoints: string[] }>;
+  priceFeedEndpoints?: PriceFeedEndpointsOptionalWrite;
   multicall?: string;
 }
 
@@ -287,8 +287,24 @@ export interface TypeSafeOrder {
 export interface PriceFeedConfig {
   network: string;
   ids: Array<{ symbol: string; id: string; type: string; origin: string }>;
-  endpoints: Array<{ type: string; endpoints: string[] }>;
+  endpoints: PriceFeedEndpoints;
 }
+
+export interface PriceFeedEndpointsItem {
+  type: string | "odin" | "pyth" | "onchain";
+  // Read only endpoints. Used by default.
+  endpoints: string[];
+  // Price feed endpoints which are used for fetching prices which will be
+  // submitted for updates on chain.
+  writeEndpoints?: string[];
+}
+
+// For price feeds config
+export type PriceFeedEndpoints = Array<Required<PriceFeedEndpointsItem>>;
+
+// For SDK configuration writeEndpoints are set as optional for backwards
+// compatibility. See NodeSDKConfig interface.
+export type PriceFeedEndpointsOptionalWrite = Array<PriceFeedEndpointsItem>;
 
 export interface PriceFeedSubmission {
   symbols: Map<string, string[]>; //id -> symbols

--- a/src/perpetualDataHandler.ts
+++ b/src/perpetualDataHandler.ts
@@ -477,15 +477,13 @@ export default class PerpetualDataHandler {
    * Get PriceFeedSubmission data required for blockchain queries that involve price data, and the corresponding
    * triangulated prices for the indices S2 and S3
    * @param symbol pool symbol of the form "ETH-USD-MATIC"
-   * @param useWriteEndpoint use price feed endpoint for writing (submission).
    * @returns PriceFeedSubmission and prices for S2 and S3. [S2price, 0] if S3 not defined.
    */
   public async fetchPriceSubmissionInfoForPerpetual(
-    symbol: string,
-    useWriteEndpoint: boolean = false
+    symbol: string
   ): Promise<{ submission: PriceFeedSubmission; pxS2S3: [number, number] }> {
     // fetch prices from required price-feeds (REST)
-    return await this.priceFeedGetter.fetchFeedPriceInfoAndIndicesForPerpetual(symbol, useWriteEndpoint);
+    return await this.priceFeedGetter.fetchFeedPriceInfoAndIndicesForPerpetual(symbol);
   }
 
   /**

--- a/src/perpetualDataHandler.ts
+++ b/src/perpetualDataHandler.ts
@@ -477,13 +477,15 @@ export default class PerpetualDataHandler {
    * Get PriceFeedSubmission data required for blockchain queries that involve price data, and the corresponding
    * triangulated prices for the indices S2 and S3
    * @param symbol pool symbol of the form "ETH-USD-MATIC"
+   * @param useWriteEndpoint use price feed endpoint for writing (submission).
    * @returns PriceFeedSubmission and prices for S2 and S3. [S2price, 0] if S3 not defined.
    */
   public async fetchPriceSubmissionInfoForPerpetual(
-    symbol: string
+    symbol: string,
+    useWriteEndpoint: boolean = false
   ): Promise<{ submission: PriceFeedSubmission; pxS2S3: [number, number] }> {
     // fetch prices from required price-feeds (REST)
-    return await this.priceFeedGetter.fetchFeedPriceInfoAndIndicesForPerpetual(symbol);
+    return await this.priceFeedGetter.fetchFeedPriceInfoAndIndicesForPerpetual(symbol, useWriteEndpoint);
   }
 
   /**

--- a/src/priceFeeds.ts
+++ b/src/priceFeeds.ts
@@ -1,7 +1,14 @@
 import { BigNumber } from "@ethersproject/bignumber";
 import { Buffer } from "buffer";
 import { decNToFloat, floatToDec18 } from "./d8XMath";
-import type { PriceFeedConfig, PriceFeedFormat, PriceFeedSubmission, PythV2LatestPriceFeed } from "./nodeSDKTypes";
+import type {
+  PriceFeedConfig,
+  PriceFeedEndpoints,
+  PriceFeedEndpointsOptionalWrite,
+  PriceFeedFormat,
+  PriceFeedSubmission,
+  PythV2LatestPriceFeed,
+} from "./nodeSDKTypes";
 import PerpetualDataHandler from "./perpetualDataHandler";
 import Triangulator from "./triangulator";
 import OnChainPxFeed from "./onChainPxFeed";
@@ -13,7 +20,11 @@ import OnChainPxFactory from "./onChainPxFactory";
  */
 export default class PriceFeeds {
   private config: PriceFeedConfig;
-  private feedEndpoints: Array<string>; //feedEndpoints[endpointId] = endpointstring
+  // Read only price info endpoints. Used by default. feedEndpoints[endpointId]
+  // = endpointstring
+  private feedEndpoints: Array<string>;
+  // Endpoints which are used to fetch prices for submissions
+  private writeFeedEndpoints: Array<string> = [];
   private feedInfo: Map<string, { symbol: string; endpointId: number }[]>; // priceFeedId -> [symbol, endpointId]
   private dataHandler: PerpetualDataHandler;
   // store triangulation paths given the price feeds
@@ -27,21 +38,16 @@ export default class PriceFeeds {
   constructor(dataHandler: PerpetualDataHandler, priceFeedConfigNetwork: string) {
     let configs = require("./config/priceFeedConfig.json") as PriceFeedConfig[];
     this.config = PriceFeeds._selectConfig(configs, priceFeedConfigNetwork);
-    // if SDK config contains custom price feed endpoints, these override the public/default ones
+
+    // if SDK config contains custom price feed endpoints, these override the
+    // public/default ones
     if (dataHandler.config.priceFeedEndpoints && dataHandler.config.priceFeedEndpoints.length > 0) {
-      // override price feed endpoints of same type
-      for (let k = 0; k < dataHandler.config.priceFeedEndpoints.length; k++) {
-        for (let j = 0; j < this.config.endpoints.length; j++) {
-          if (this.config.endpoints[j].type == dataHandler.config.priceFeedEndpoints[k].type) {
-            this.config.endpoints[j] = dataHandler.config.priceFeedEndpoints[k];
-            for (let i = 0; i < this.config.endpoints[j].endpoints.length; i++) {
-              this.config.endpoints[j].endpoints[i] = PriceFeeds.trimEndpoint(this.config.endpoints[j].endpoints[i]);
-            }
-            break;
-          }
-        }
-      }
+      this.config.endpoints = PriceFeeds.overridePriceEndpointsOfSameType(
+        this.config.endpoints,
+        dataHandler.config.priceFeedEndpoints
+      );
     }
+
     this.onChainPxFeeds = new Map<string, OnChainPxFeed>();
     for (let k = 0; k < this.config.ids.length; k++) {
       if (this.config.ids[k].type == "onchain") {
@@ -49,9 +55,54 @@ export default class PriceFeeds {
         this.onChainPxFeeds[sym] = OnChainPxFactory.createFeed(sym);
       }
     }
-    [this.feedInfo, this.feedEndpoints] = PriceFeeds._constructFeedInfo(this.config, false);
+    [this.feedInfo, this.feedEndpoints, this.writeFeedEndpoints] = PriceFeeds._constructFeedInfo(this.config, false);
+    // Deny providing no endpoints
+    if (this.feedEndpoints.length == 0) {
+      throw new Error("PriceFeeds: no endpoints provided in config");
+    }
+    if (this.writeFeedEndpoints.length == 0) {
+      throw new Error("PriceFeeds: no writeEndpoints provided in config");
+    }
+
     this.dataHandler = dataHandler;
     this.triangulations = new Map<string, [string[], boolean[]]>();
+  }
+
+  // overridePriceEndpointsOfSameType overrides endpoints of config with same
+  // type endpoints provided by user and returns the updated price feed
+  // endpoints list.
+  public static overridePriceEndpointsOfSameType(
+    configEndpoints: PriceFeedEndpoints,
+    userProvidedEndpoints: PriceFeedEndpointsOptionalWrite
+  ): PriceFeedEndpoints {
+    let result = configEndpoints;
+    for (let k = 0; k < userProvidedEndpoints.length; k++) {
+      for (let j = 0; j < result.length; j++) {
+        if (result[j].type == userProvidedEndpoints[k].type) {
+          // read only endpoints
+          if (userProvidedEndpoints[k].endpoints.length > 0) {
+            result[j].endpoints = userProvidedEndpoints[k].endpoints;
+            for (let i = 0; i < result[j].endpoints.length; i++) {
+              result[j].endpoints[i] = PriceFeeds.trimEndpoint(result[j].endpoints[i]);
+            }
+          }
+
+          // write endpoints
+          if (
+            userProvidedEndpoints[k].writeEndpoints !== undefined &&
+            userProvidedEndpoints[k].writeEndpoints!.length > 0
+          ) {
+            result[j].writeEndpoints = userProvidedEndpoints[k].writeEndpoints!;
+            for (let i = 0; i < result[j].writeEndpoints.length; i++) {
+              result[j].writeEndpoints[i] = PriceFeeds.trimEndpoint(result[j].writeEndpoints[i]);
+            }
+          }
+
+          break;
+        }
+      }
+    }
+    return result;
   }
 
   /**
@@ -101,17 +152,19 @@ export default class PriceFeeds {
   }
 
   /**
-   * Get required information to be able to submit a blockchain transaction with price-update
-   * such as trade execution, liquidation
+   * Get required information to be able to submit a blockchain transaction with
+   * price-update such as trade execution, liquidation
    * @param symbol symbol of perpetual, e.g., BTC-USD-MATIC
+   * @param useWriteEndpoint use price feed endpoint for writing (submission).
    * @returns PriceFeedSubmission, index prices, market closed information
    */
   public async fetchFeedPriceInfoAndIndicesForPerpetual(
-    symbol: string
+    symbol: string,
+    useWriteEndpoint: boolean = true
   ): Promise<{ submission: PriceFeedSubmission; pxS2S3: [number, number]; mktClosed: [boolean, boolean] }> {
     let indexSymbols = this.dataHandler.getIndexSymbols(symbol);
     // fetch prices from required price-feeds (REST)
-    let submission: PriceFeedSubmission = await this.fetchLatestFeedPriceInfoForPerpetual(symbol);
+    let submission: PriceFeedSubmission = await this.fetchLatestFeedPriceInfoForPerpetual(symbol, useWriteEndpoint);
     // calculate index-prices from price-feeds
     let [_idxPrices, _mktClosed] = this.calculateTriangulatedPricesFromFeedInfo(
       indexSymbols.filter((x) => x != ""),
@@ -128,8 +181,9 @@ export default class PriceFeeds {
 
   /**
    * Get all prices/isMarketClosed for the provided symbols via
-   * "latest_price_feeds" and triangulation. Triangulation must be defined in config, unless
-   * it is a direct price feed.
+   * "latest_price_feeds" and triangulation. Triangulation must be defined in
+   * config, unless it is a direct price feed. Uses read endpoints.
+   * @param symbol perpetual symbol of the form BTC-USD-MATIC
    * @returns map of feed-price symbol to price/isMarketClosed
    */
   public async fetchPrices(symbols: string[]): Promise<Map<string, [number, boolean]>> {
@@ -179,8 +233,10 @@ export default class PriceFeeds {
    * Fetch the provided feed prices and bool whether market is closed or open
    * - requires the feeds to be defined in priceFeedConfig.json
    * - if symbols undefined, all feeds are queried
-   * - vaas are not of interest here
-   * @param symbols array of feed-price symbols (e.g., [btc-usd, eth-usd]) or undefined
+   * - vaas are not of interest here, therefore only readonly price feed
+   *   endpoints are used
+   * @param symbols array of feed-price symbols (e.g., [btc-usd, eth-usd]) or
+   * undefined
    * @returns mapping symbol-> [price, isMarketClosed]
    */
   public async fetchFeedPrices(symbols?: string[]): Promise<Map<string, [number, boolean]>> {
@@ -249,21 +305,30 @@ export default class PriceFeeds {
   }
 
   /**
-   * Get all configured feed prices via "latest_price_feeds"
+   * Get all configured feed prices via "latest_price_feeds".
+   * @param useWriteEndpoint use price feed endpoint for writing (submission).
    * @returns map of feed-price symbol to price/isMarketClosed
    */
   public async fetchAllFeedPrices(): Promise<Map<string, [number, boolean]>> {
     return this.fetchFeedPrices();
   }
 
+  public getEndpoint(endpointId: number, isWrite: boolean): string {
+    return isWrite ? this.writeFeedEndpoints[endpointId] : this.feedEndpoints[endpointId];
+  }
+
   /**
    * Get the latest prices for a given perpetual from the offchain oracle
    * networks
    * @param symbol perpetual symbol of the form BTC-USD-MATIC
-   * @returns array of price feed updates that can be submitted to the smart contract
-   * and corresponding price information
+   * @param useWriteEndpoint use price feed endpoint for writing (submission).
+   * @returns array of price feed updates that can be submitted to the smart
+   * contract and corresponding price information
    */
-  public async fetchLatestFeedPriceInfoForPerpetual(symbol: string): Promise<PriceFeedSubmission> {
+  public async fetchLatestFeedPriceInfoForPerpetual(
+    symbol: string,
+    useWriteEndpoint: boolean = true
+  ): Promise<PriceFeedSubmission> {
     // get the feedIds that the contract uses
     let feedIds = this.dataHandler.getPriceIds(symbol);
     let queries = new Array<string>();
@@ -277,7 +342,10 @@ export default class PriceFeeds {
       // and another
       let idx = info[0].endpointId;
       let feedId = feedIds[k];
-      queries.push(this.feedEndpoints[idx] + "/v2/updates/price/latest?encoding=base64&ids[]=" + feedId);
+      queries.push(
+        this.getEndpoint(idx, useWriteEndpoint) + "/v2/updates/price/latest?encoding=base64&ids[]=" + feedId
+      );
+
       for (let j = 0; j < info.length; j++) {
         if (symbols.has(feedId)) {
           symbols[feedId].append(info[j].symbol);
@@ -481,11 +549,12 @@ export default class PriceFeeds {
   static _constructFeedInfo(
     config: PriceFeedConfig,
     shuffleEndpoints: boolean
-  ): [Map<string, { symbol: string; endpointId: number }[]>, string[]] {
+  ): [Map<string, { symbol: string; endpointId: number }[]>, string[], string[]] {
     let feed = new Map<string, [{ symbol: string; endpointId: number }]>();
     let endpointId = -1;
     let type = "";
     let feedEndpoints = new Array<string>();
+    let writeFeedEndpoints = new Array<string>();
 
     for (let k = 0; k < config.endpoints.length; k++) {
       const L = config.endpoints[k].endpoints.length;
@@ -493,7 +562,13 @@ export default class PriceFeeds {
       // if config has only one endpoint:
       endpointNr = Math.min(endpointNr, L - 1);
       feedEndpoints.push(config.endpoints[k].endpoints[endpointNr]);
+
+      // write endpoints
+      const n = config.endpoints[k].writeEndpoints.length;
+      const useEndpoint = Math.min(!shuffleEndpoints ? 0 : 1 + Math.floor(Math.random() * (n - 1)), n - 1);
+      writeFeedEndpoints.push(config.endpoints[k].writeEndpoints[useEndpoint]);
     }
+
     for (let k = 0; k < config.ids.length; k++) {
       if (type != config.ids[k].type) {
         type = config.ids[k].type;
@@ -518,6 +593,6 @@ export default class PriceFeeds {
         feed.set(id, [item]);
       }
     }
-    return [feed, feedEndpoints];
+    return [feed, feedEndpoints, writeFeedEndpoints];
   }
 }

--- a/test/priceFeed.test.ts
+++ b/test/priceFeed.test.ts
@@ -25,7 +25,7 @@ describe("priceFeed", () => {
       config.nodeURL = RPC;
     }
     config.priceFeedEndpoints = [
-      { type: "pyth", endpoints: ["https://hermes.pyth.network/api"] }, //, "https://xc-testnet.pyth.network/api"] },
+      { type: "pyth", endpoints: ["https://hermes.pyth.network/api"], writeEndpoints: [] }, //, "https://xc-testnet.pyth.network/api"] },
     ];
     mktData = new MarketData(config);
     await mktData.createProxyInstance();
@@ -33,7 +33,7 @@ describe("priceFeed", () => {
 
   it("should correctly construct non-unique price id price feeds", async () => {
     const FakePriceFeedsConfig: PriceFeedConfig = {
-      endpoints: [{ endpoints: ["https://hermes.pyth.network"], type: "pyth" }],
+      endpoints: [{ endpoints: ["https://hermes.pyth.network"], type: "pyth", writeEndpoints: [] }],
       network: "pyth",
       ids: [
         {
@@ -155,5 +155,25 @@ describe("priceFeed", () => {
   it("fetch info from data handler", async () => {
     let l = await mktData.fetchPriceSubmissionInfoForPerpetual(perp);
     console.log(l);
+  });
+
+  it("should correctly override endpoints of same type", () => {
+    const result = PriceFeeds.overridePriceEndpointsOfSameType(
+      [
+        { endpoints: ["a", "b", "c"], type: "pyth", writeEndpoints: ["w1", "w2"] },
+        { endpoints: ["a", "b", "c"], type: "non-overriden-pyth", writeEndpoints: ["w-pyth-3"] },
+        { endpoints: ["a", "b", "c"], type: "pyth-2-empty-write", writeEndpoints: [] },
+      ],
+      [
+        { endpoints: ["user-provided-endpoint"], type: "pyth", writeEndpoints: ["w-user-1"] },
+        { endpoints: ["d", "e", "f"], type: "pyth-2-empty-write", writeEndpoints: ["write-1", "write-2"] },
+      ]
+    );
+
+    expect(result).toEqual([
+      { endpoints: ["user-provided-endpoint"], type: "pyth", writeEndpoints: ["w-user-1"] },
+      { endpoints: ["a", "b", "c"], type: "non-overriden-pyth", writeEndpoints: ["w-pyth-3"] },
+      { endpoints: ["d", "e", "f"], type: "pyth-2-empty-write", writeEndpoints: ["write-1", "write-2"] },
+    ]);
   });
 });

--- a/test/priceFeed.test.ts
+++ b/test/priceFeed.test.ts
@@ -5,6 +5,7 @@ import PriceFeeds from "../src/priceFeeds";
 
 let pk: string = <string>process.env.PK;
 let RPC: string = <string>process.env.RPC;
+const SdkConfigName = "arbitrum";
 
 jest.setTimeout(150000);
 
@@ -19,8 +20,7 @@ describe("priceFeed", () => {
     }
     //config = PerpetualDataHandler.readSDKConfig("xlayer");
     //perp="BTC-USDT-USDT"
-    config = PerpetualDataHandler.readSDKConfig("arbitrum");
-    perp = "BTC-USD-STUSD";
+    config = PerpetualDataHandler.readSDKConfig(SdkConfigName);
     if (RPC != undefined) {
       config.nodeURL = RPC;
     }
@@ -156,7 +156,6 @@ describe("priceFeed", () => {
     let l = await mktData.fetchPriceSubmissionInfoForPerpetual(perp);
     console.log(l);
   });
-
   it("should correctly override endpoints of same type", () => {
     const result = PriceFeeds.overridePriceEndpointsOfSameType(
       [
@@ -175,5 +174,20 @@ describe("priceFeed", () => {
       { endpoints: ["a", "b", "c"], type: "non-overriden-pyth", writeEndpoints: ["w-pyth-3"] },
       { endpoints: ["d", "e", "f"], type: "pyth-2-empty-write", writeEndpoints: ["write-1", "write-2"] },
     ]);
+  });
+});
+
+describe("priceFeed configs", () => {
+  it("should not require to fill in write price feed endpoints in sdk config", async () => {
+    const cfg = PerpetualDataHandler.readSDKConfig(SdkConfigName);
+    cfg.priceFeedEndpoints = [
+      // No write endpoints
+      { type: "pyth", endpoints: ["test-url-price-feed"] },
+    ];
+    const md = new MarketData(cfg);
+    // Do not create proxy instance
+    // await md.createProxyInstance();
+    const priceFeeds = new PriceFeeds(md, cfg.priceFeedConfigNetwork);
+    expect(priceFeeds.writeFeedEndpoints.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
This PR introduces write endpoints for price feeds in price feeds class and configuration.

Write price feeds are used for fetching prices when VAAs are needed for price submission. Previous configuration for priceFeeds and `NodeSDKConfig` is kept backwards compatible, therefore, no additional configuration should be needed for code using previous versions of sdk. 